### PR TITLE
Correct channel mappings for RTP Internacional & RTP Memória

### DIFF
--- a/src/channels.json
+++ b/src/channels.json
@@ -8,10 +8,10 @@
   "rtpn": {
     "is_tv": true
   },
-  "rpti": {
+  "rtpi": {
     "is_tv": true
   },
-  "rtpmemoria": {
+  "rtpmem": {
     "is_tv": true
   },
   "rtpmadeira": {


### PR DESCRIPTION
Channel mappings for RTP Internacional and RTP Memória did not match the live URLs, and were resulting in the application delivering blank m3u8 playlists for those channels.
  